### PR TITLE
switch to 2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>jakarta.inject-api</artifactId>
   <packaging>jar</packaging>
   <name>Jakarta Dependency Injection</name>
-  <version>2.0</version>
+  <version>2.0-SNAPSHOT</version>
   <description>Jakarta Dependency Injection</description>
   <url>https://github.com/eclipse-ee4j/injection-api</url>
   <licenses>


### PR DESCRIPTION
Should we use 2.0-SNAPSHOT for the version?  
